### PR TITLE
Fix: Submitter ID for Lungmap is based on wrong slug (#35)

### DIFF
--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -1652,7 +1652,7 @@ from the tracking spreadsheet column named ``file_source`` e.g.
 ``contributor``, ``hca release``, ``arrayexpress`` and so on. A complete list
 can be found in the `Azul source`_ [#]_.
 
-.. _Azul source: https://github.com/DataBiosphere/azul/blob/a820e259ba9e37a94b5788a257d4c6f43fe31801/src/azul/plugins/metadata/hca/transform.py#L271
+.. _Azul source: https://github.com/DataBiosphere/azul/blob/bd666cdea14e66ad0a1612f126b2fcb9676c4af0/src/azul/plugins/metadata/hca/transform.py#L275
 
 The ``format`` property of a contributor-generated matrix file is set to the
 extension of the matrix file e.g., ``zip``, ``csv``, ``h5ad``, ``mtx.gz``,


### PR DESCRIPTION
In [section 5.1.1: Describing CGMs as supplementary files](https://github.com/HumanCellAtlas/dcp2/blob/main/docs/dcp2_system_design.rst#511describing-cgms-as-supplementary-files) of the "DCP/2 System Design" document, a link is provided to the Azul source code for the reader to obtain a full list of the UUIDs that can be set in the file's `submitter_id` field to identify the supplementary file as a CGM.

This PR updates that link to the latest version of the Azul source code to reflect a change made to the UUID associated with   the contributor `Lungmap`. The slug used to generate the UUID was changed from `lungmap_external` to `lungmap`, causing the UUID to change from `fedbcffc-4ebc-54f7-8a21-fc63836ef8bb` to `31ad7d2c-7262-54aa-92df-7f16418f3b84`.