### PR TITLE
Add section capturing external DRS URIs

### DIFF
--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -486,7 +486,7 @@ of the descriptor.
 
 The importer will skip any attempt to import the externally referenced files.
 Downstream consumers of these file descriptors must be resilient to a row with
-a ```NULL`` value in the TDR ``file_id`` column and fall back to using the
+a ``NULL`` value in the TDR ``file_id`` column and fall back to using the
 ``drs_uri`` property of the descriptor JSON in the ``content`` column of the
 same row.
 

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -475,18 +475,19 @@ External DRS File URIs
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Some files may be hosted by an external DRS repository and are not available for
-import to the repository. In these cases, the ``drs_uri`` property may be provided
+import to the TDR. In these cases, the ``drs_uri`` property may be provided
 in the file descriptor to indicate this to the importer. A descriptor with
 this property set will cause a ``null`` value in the ``file_id`` column of the
 ``…_file`` table row for the data file referenced in the descriptor, in any TDR
-snapshot containing the data file. [#]_,
-The importer will skip any attempt to import the externally referenced files.
-Downstream consumers of these file descriptors must be resilient to a ```NULL``
-TDR ``file_id`` column and fall back to using the DRS URI as provided in the
-descriptor ``content`` column.
+snapshot containing the data file.[#]_
 
-The ``drs_uri`` property must be a URI utilizing the ``drs://`` scheme. Content
-hashes are required for descriptors of this nature.
+The importer will skip any attempt to import the externally referenced files.
+Downstream consumers of these file descriptors must be resilient to a row with a ```NULL`` value
+in the TDR ``file_id`` column and fall back to using the ``drs_uri`` property of the
+descriptor JSON in the ``content`` column of the same row.
+
+The ``drs_uri`` property must be a URI utilizing the ``drs://`` scheme. As for regular files, descriptors for files at external DRS URIs are required to have the ``crc32c`` and ``sha256`` content
+hashes.
 
 A descriptor with the ``drs_uri`` property set follows below::
 
@@ -506,7 +507,7 @@ A descriptor with the ``drs_uri`` property set follows below::
     }
 
 .. [#]
-    The TDR ``file_id`` field is distinct than the ``file_id`` field as
+    The TDR ``file_id`` column is distinct from the ``file_id`` property as
     expressed in the ``file_descriptor`` `metadata schema`_, and is populated by
     TDR during the import process.
 

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -470,6 +470,33 @@ SHA-256 hashes of the data file's content.
    hashes (and UUIDs for that matter) using a case sensitive quality
    comparison
 
+External DRS File URIs
+~~~~~~~~~~~~~~~~~~~~~~
+Some files may be hosted by an external DRS repository and are not available for import
+to the repository. In these cases, the `drs_uri` field may be provided in the file descriptor
+to indicate to this to the importer. Descriptors with this value set will receive an empty TDR
+`file_id` value after import to TDR [#]_, and the importer will skip any attempt to import
+the related data file.  Downstream consumers of these file descriptors must be resilient to
+`NULL` TDR `file_id` fields and fall back to using the DRS URI in the descriptor content field.
+
+Externally hosted files do not require a provided hash (i.e., ``crc32c``, ``sha1``, ``sha256`` and ``s3_etag``).
+The `drs_uri` field must be a URI utilizing the `drs://` scheme.
+A descriptor with the `drs_uri` field set follows below::
+
+    {
+        "describedBy": "https://schema.humancellatlas.org/system/1.0.0/file_descriptor",
+        "schema_version": "1.0.0",
+        "schema_type": "file_descriptor",
+        "file_name": "1b6d8348-d6e9-406a-aa6a-7ee886e52bf9/IDC9_L004_R2.fastq.gz",
+        "size": 4218464933,
+        "file_id": "ae5d1035-8f2b-4355-a0ef-bbb99958b303",
+        "file_version": "2020-05-01T04:26:07.021870Z",
+        "drs_uri": "drs://example.org/123abc"
+    }
+
+.. [#]
+    The TDR `file_id` field is distinct than the `file_id` field as expressed in the `file_descriptor`
+    metadata schema, and is populated by TDR during the import process.
 
 Analysis provenance
 -------------------

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -511,6 +511,7 @@ An example of a descriptor with the ``drs_uri`` property set follows below::
         "schema_version": "1.0.0",
         "schema_type": "file_descriptor",
         "file_name": "1b6d8348-d6e9-406a-aa6a-7ee886e52bf9/IDC9_L004_R2.fastq.gz",
+        "content_type": "application/binary",
         "size": 4218464933,
         "file_id": "ae5d1035-8f2b-4355-a0ef-bbb99958b303",
         "file_version": "2020-05-01T04:26:07.021870Z",

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -491,7 +491,7 @@ hashes.
 
 If the ``drs_uri`` property has the ``null`` value, the data file is presently not available, neither in the staging area nor in an external DRS repository, but may be made available in the future, along with an updated descriptor referencing it. File descriptors with a ``null`` value for ``drs_uri`` are colloquially known as *phantom files*. Note that the staging area source must either provide the ``drs_uri`` property in the descriptor or a data file in the staging area. Omitting both is not valid and does not indicate a phantom file. The source must explicitly set ``drs_uri`` to ``null`` to indicate phantom files. As mentioned above, providing both is also invalid.
 
-A descriptor with the ``drs_uri`` property set follows below::
+An example of a descriptor with the ``drs_uri`` property set follows below::
 
     {
         "describedBy": "https://schema.humancellatlas.org/system/1.0.0/file_descriptor",

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -492,8 +492,7 @@ same row.
 
 The ``drs_uri`` property must be ``null`` or a string containing a URI utilizing
  the ``drs://`` scheme. As for regular files, descriptors for files at external
-DRS URIs are required to have the ``crc32c`` and ``sha256`` content
-hashes.
+DRS URIs are required to have the ``crc32c`` and ``sha256`` content hashes.
 
 If the ``drs_uri`` property has the ``null`` value, the data file is presently
 not available, neither in the staging area nor in an external DRS repository,

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -507,8 +507,10 @@ A descriptor with the ``drs_uri`` property set follows below::
 
 .. [#]
     The TDR ``file_id`` field is distinct than the ``file_id`` field as
-    expressed in the `file_descriptor` metadata schema, and is populated by
+    expressed in the ``file_descriptor`` `metadata schema`_, and is populated by
     TDR during the import process.
+
+.. _metadata schema: https://github.com/HumanCellAtlas/metadata-schema/blob/master/json_schema/system/file_descriptor.json
 
 Analysis provenance
 -------------------

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -485,8 +485,10 @@ Downstream consumers of these file descriptors must be resilient to a ```NULL``
 TDR ``file_id`` column and fall back to using the DRS URI as provided in the
 descriptor ``content`` column.
 
-The ``drs_uri`` property must be a URI utilizing the ``drs://`` scheme. Content
-hashes are required for descriptors of this nature.
+The ``drs_uri`` property must be one of:
+- a URI utilizing the ``drs://`` scheme
+- JSON `null` to indicate that a file will be present in the future
+Content hashes are required for descriptors of this nature.
 
 A descriptor with the ``drs_uri`` property set follows below::
 

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -486,7 +486,7 @@ Downstream consumers of these file descriptors must be resilient to a row with a
 in the TDR ``file_id`` column and fall back to using the ``drs_uri`` property of the
 descriptor JSON in the ``content`` column of the same row.
 
-The ``drs_uri`` property must be a URI utilizing the ``drs://`` scheme. As for regular files, descriptors for files at external DRS URIs are required to have the ``crc32c`` and ``sha256`` content
+The ``drs_uri`` property must be ``null`` or a string containing a URI utilizing the ``drs://`` scheme. As for regular files, descriptors for files at external DRS URIs are required to have the ``crc32c`` and ``sha256`` content
 hashes.
 
 If the ``drs_uri`` property has the ``null`` value, the data file is presently not available, neither in the staging area nor in an external DRS repository, but may be made available in the future, along with an updated descriptor referencing it. File descriptors with a ``null`` value for ``drs_uri`` are colloquially known as *phantom files*. Note that the staging area source must either provide the ``drs_uri`` property in the descriptor or a data file in the staging area. Omitting both is not valid and does not indicate a phantom file. The source must explicitly set ``drs_uri`` to ``null`` to indicate phantom files. As mentioned above, providing both is also invalid.

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -476,7 +476,7 @@ External DRS File URIs
 
 Some files may be hosted by an external DRS repository and are not available for
 import to the repository. In these cases, the ``drs_uri`` property may be provided
-in the file descriptor to indicate this to the importer. A descriptors with
+in the file descriptor to indicate this to the importer. A descriptor with
 this property set will cause a ``null`` value in the ``file_id`` column of the
 ``…_file`` table row for the data file referenced in the descriptor, in any TDR
 snapshot containing the data file. [#]_,

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -479,7 +479,7 @@ import to the TDR. In these cases, the ``drs_uri`` property may be provided
 in the file descriptor to indicate this to the importer. A descriptor with
 this property set will cause a ``null`` value in the ``file_id`` column of the
 ``…_file`` table row for the data file referenced in the descriptor, in any TDR
-snapshot containing the data file.[#]_
+snapshot containing the data file.[#]_ If this property is provided in a descriptor, regardless of its value, the staging area may not contain an object at the path `data/{file_name}` where ``file_name`` is the ``file_name`` property of the descriptor.
 
 The importer will skip any attempt to import the externally referenced files.
 Downstream consumers of these file descriptors must be resilient to a row with a ```NULL`` value

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -475,7 +475,7 @@ External DRS File URIs
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Some files may be hosted by an external DRS repository and are not available for
-import to the TDR. In these cases, the ``drs_uri`` property may be provided
+import to the TDR. In these cases, the ``drs_uri`` property must be provided
 in the file descriptor to indicate this to the importer. A descriptor with
 this property set will cause a ``null`` value in the ``file_id`` column of the
 ``…_file`` table row for the data file referenced in the descriptor, in any TDR

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -470,18 +470,25 @@ SHA-256 hashes of the data file's content.
    hashes (and UUIDs for that matter) using a case sensitive quality
    comparison
 
+
 External DRS File URIs
 ~~~~~~~~~~~~~~~~~~~~~~
-Some files may be hosted by an external DRS repository and are not available for import
-to the repository. In these cases, the `drs_uri` field may be provided in the file descriptor
-to indicate to this to the importer. Descriptors with this value set will receive an empty TDR
-`file_id` value after import to TDR [#]_, and the importer will skip any attempt to import
-the related data file.  Downstream consumers of these file descriptors must be resilient to
-`NULL` TDR `file_id` fields and fall back to using the DRS URI in the descriptor content field.
 
-Externally hosted files do not require a provided hash (i.e., ``crc32c``, ``sha1``, ``sha256`` and ``s3_etag``).
-The `drs_uri` field must be a URI utilizing the `drs://` scheme.
-A descriptor with the `drs_uri` field set follows below::
+Some files may be hosted by an external DRS repository and are not available for
+import to the repository. In these cases, the ``drs_uri`` property may be provided
+in the file descriptor to indicate this to the importer. A descriptors with
+this property set will cause a ``null`` value in the ``file_id`` column of the
+``…_file`` table row for the data file referenced in the descriptor, in any TDR
+snapshot containing the data file. [#]_,
+The importer will skip any attempt to import the externally referenced files.
+Downstream consumers of these file descriptors must be resilient to a ```NULL``
+TDR ``file_id`` column and fall back to using the DRS URI as provided in the
+descriptor ``content`` column.
+
+The ``drs_uri`` property must be a URI utilizing the ``drs://`` scheme. Content
+hashes are required for descriptors of this nature.
+
+A descriptor with the ``drs_uri`` property set follows below::
 
     {
         "describedBy": "https://schema.humancellatlas.org/system/1.0.0/file_descriptor",
@@ -491,12 +498,17 @@ A descriptor with the `drs_uri` field set follows below::
         "size": 4218464933,
         "file_id": "ae5d1035-8f2b-4355-a0ef-bbb99958b303",
         "file_version": "2020-05-01T04:26:07.021870Z",
-        "drs_uri": "drs://example.org/123abc"
+        "drs_uri": "drs://example.org/123abc",
+        "crc32c": "0b83b575",
+        "sha1": "9ee5c924eb8cce21b2544b92cea7df0ac84e6e2f",
+        "sha256": "4c9b22cfd3eb141a30a43fd52ce576b586279ca021444ff191c460a26cf1e4cc",
+        "s3_etag": "c92e5374ac0a53b228d4c1511c2d2842-63"
     }
 
 .. [#]
-    The TDR `file_id` field is distinct than the `file_id` field as expressed in the `file_descriptor`
-    metadata schema, and is populated by TDR during the import process.
+    The TDR ``file_id`` field is distinct than the ``file_id`` field as
+    expressed in the `file_descriptor` metadata schema, and is populated by
+    TDR during the import process.
 
 Analysis provenance
 -------------------

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -489,6 +489,8 @@ descriptor JSON in the ``content`` column of the same row.
 The ``drs_uri`` property must be a URI utilizing the ``drs://`` scheme. As for regular files, descriptors for files at external DRS URIs are required to have the ``crc32c`` and ``sha256`` content
 hashes.
 
+If the ``drs_uri`` property has the ``null`` value, the data file is presently not available, neither in the staging area nor in an external DRS repository, but may be made available in the future, along with an updated descriptor referencing it. File descriptors with a ``null`` value for ``drs_uri`` are colloquially known as *phantom files*. Note that the staging area source must either provide the ``drs_uri`` property in the descriptor or a data file in the staging area. Omitting both is not valid and does not indicate a phantom file. The source must explicitly set ``drs_uri`` to ``null`` to indicate phantom files. As mentioned above, providing both is also invalid.
+
 A descriptor with the ``drs_uri`` property set follows below::
 
     {

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -508,7 +508,7 @@ An example of a descriptor with the ``drs_uri`` property set follows below::
 
     {
         "describedBy": "https://schema.humancellatlas.org/system/2.1.0/file_descriptor",
-        "schema_version": "1.0.0",
+        "schema_version": "2.1.0",
         "schema_type": "file_descriptor",
         "file_name": "1b6d8348-d6e9-406a-aa6a-7ee886e52bf9/IDC9_L004_R2.fastq.gz",
         "content_type": "application/binary",

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -507,7 +507,7 @@ files. As mentioned above, providing both is also invalid.
 An example of a descriptor with the ``drs_uri`` property set follows below::
 
     {
-        "describedBy": "https://schema.humancellatlas.org/system/1.0.0/file_descriptor",
+        "describedBy": "https://schema.humancellatlas.org/system/2.1.0/file_descriptor",
         "schema_version": "1.0.0",
         "schema_type": "file_descriptor",
         "file_name": "1b6d8348-d6e9-406a-aa6a-7ee886e52bf9/IDC9_L004_R2.fastq.gz",

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -491,7 +491,7 @@ a ``NULL`` value in the TDR ``file_id`` column and fall back to using the
 same row.
 
 The ``drs_uri`` property must be ``null`` or a string containing a URI utilizing
- the ``drs://`` scheme. As for regular files, descriptors for files at external
+the ``drs://`` scheme. As for regular files, descriptors for files at external
 DRS URIs are required to have the ``crc32c`` and ``sha256`` content hashes.
 
 If the ``drs_uri`` property has the ``null`` value, the data file is presently


### PR DESCRIPTION
## Context

The Lungmap project has a requirement to source files from an external system that will provide DRS URIs. These files will not be importable to TDR but the DRS URIs will need to be wired through into the file descriptor so they can be surfaced downstream in the browser. This is a draft PR capturing a proposal to allow the inclusion of these external DRS URIs.

[Related schema PR](https://github.com/HumanCellAtlas/metadata-schema/pull/1437/files)
<!--
Please make sure to provide a meaningful title for your PR. 
Do not keep the default title.
-->

<!--
Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
completely resolves an issue:
"Fixes #123" or "Closes #456"
-->

<!-- 
Describe how you tested this PR, and how you will test the feature after it is
merged. Uncomment below:

### Test plan
-->

<!--
Describe any special instructions to the operator who will deploy your code to
the integration, staging and production deployments. Uncomment below:

### Deployment instructions & migrations
-->

<!-- 
Add notes to highlight the feature when it's released/demoed. Uncomment the
headings below:

### Release notes
-->

<!--
Do you want your PR to be merged by the reviewer using squash or rebase
merging? If so, mention it here.
-->
