### PR TITLE
Fix: Rendering of non-normative text is broken

### DIFF
--- a/docs/dcp2_operating_procedures.rst
+++ b/docs/dcp2_operating_procedures.rst
@@ -4,8 +4,8 @@
 
 .. role:: raw-html(raw)
    :format: html
-.. |nn| replace:: :raw-html:`<blockquote>`
-.. |ne| replace:: :raw-html:`</blockquote>`
+.. |nn| replace:: ``Non-normative note:``
+.. |ne| replace:: ``(end of note)``
 
 
 
@@ -14,8 +14,8 @@
 DCP/2 Operating Procedures
 ==========================
 
-|nn| Text in a block quote (like this) is not normative. It was included
-for informational purposes only and does not bear on the implementation. |ne|
+Text between |nn| and |ne| is not normative. It is included for informational
+purposes only and does not bear on the implementation.
 
 .. contents::
 

--- a/docs/dcp2_system_design.rst
+++ b/docs/dcp2_system_design.rst
@@ -4,8 +4,8 @@
 
 .. role:: raw-html(raw)
    :format: html
-.. |nn| replace:: :raw-html:`<blockquote>`
-.. |ne| replace:: :raw-html:`</blockquote>`
+.. |nn| replace:: ``Non-normative note:``
+.. |ne| replace:: ``(end of note)``
 
 
 
@@ -14,8 +14,8 @@
 DCP/2 System Design
 ===================
 
-|nn| Text in a block quote (like this) is not normative. It was included for
-informational purposes only and does not bear on the implementation. |ne|
+Text between |nn| and |ne| is not normative. It is included for informational
+purposes only and does not bear on the implementation.
 
 .. contents::
 


### PR DESCRIPTION
GitHub's fix for https://github.com/orgs/community/discussions/86715 broke the raw-HTML mechanism that we used for rendering non-normative text as a block quote. We'll have to resort to something more literal.

