### PR TITLE
Deleted Enrique from designated reviewers on operating procedures document

### DIFF
--- a/docs/dcp2_operating_procedures.rst
+++ b/docs/dcp2_operating_procedures.rst
@@ -311,7 +311,6 @@ PR author invites the `Mediators`_ and all reviewers currently on the PR.
 Designated reviewers
 ~~~~~~~~~~~~~~~~~~~~
 
-- Enrique aka ``@ESapenaVentura`` (EBI)
 - Amnon aka ``@amnonkhen`` (EBI)
 - Nate aka ``@ncalvanese1`` (Broad)
 - Hannes aka ``@hannes-ucsc`` (UCSC)


### PR DESCRIPTION
On `docs/dcp2_operating_procedures.rst` document:

- Deleted @ESapenaVentura (Myself) from the list of designated reviewers as per discussion on the DCP demos (11-02-2025).

EBI still has @amnonkhen as a designated reviewer.

It's probably a good idea to either lower my permissions (read-only) or remove me from this repository

It was a pleasure working with everyone!